### PR TITLE
Fix outdated dependency resolution

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,9 +1,9 @@
-channels = ["anaconda", "conda-forge"]
+channels = ["conda-forge", "anaconda"]
 
 [deps]
 python = ">=3.8,<3.11"
+numpy = ">=1.20.0"
+pytorch-cpu = ">=2.0.1"
 
 [pip.deps]
-numpy          = ">=1.20.0"
-torch          = ">=2.0.1"
-cim-optimizer  = "==1.0.4"
+cim-optimizer = "==1.0.4"

--- a/Project.toml
+++ b/Project.toml
@@ -10,5 +10,13 @@ QUBODrivers = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
 
 [compat]
 PythonCall = "0.9"
-QUBODrivers = "0.2"
-julia = "1.6"
+QUBODrivers = "0.4"
+julia = "1.10"
+
+[extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Pkg", "TOML", "Test"]

--- a/src/CIMOptimizer.jl
+++ b/src/CIMOptimizer.jl
@@ -2,7 +2,7 @@ module CIMOptimizer
 
 using PythonCall
 using LinearAlgebra
-using QUBODrivers: QUBODrivers, QUBOTools, MOI, Sample, SampleSet, ising
+using QUBODrivers: QUBODrivers, QUBOTools, MOI, Sample, SampleSet
 
 const np = PythonCall.pynew()
 const co = PythonCall.pynew()
@@ -18,8 +18,6 @@ end
 
 QUBODrivers.@setup Optimizer begin
     name = "cim-optimizer"
-    sense = :min
-    domain = :spin
     version = v"1.0.4" # cim-optimizer version
     attributes = begin
         "target_energy"::Number = -Inf                                  # Assumed target/ground energy for the solver to reach, used to stop before num_runs runs have been completed.
@@ -73,12 +71,12 @@ QUBODrivers.@setup Optimizer begin
 end
 
 function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
-    h, J, α, β = ising(sampler, Matrix)
+    _, h, J, α, β, _, _ = QUBOTools.ising(sampler, :dense; sense = :min)
 
-    # cim-optimzier asks for symmetric 'J', and its convention
+    # cim-optimizer asks for symmetric 'J', and its convention
     # is to min -s'J s -h's
     h = np.array(-h)
-    J = np.array(-Symmetric(J))
+    J = np.array(-Matrix(Symmetric(J)))
 
     model = co_si.Ising(J, h)
 
@@ -146,7 +144,8 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     samples = Vector{Sample{T,Int}}(undef, num_runs)
 
     for i = 1:num_runs
-        ψ = round.(Int, pyconvert.(T, solver.result["spin_config_all_runs"][i-1]))
+        spin_config = np.asarray(solver.result["spin_config_all_runs"][i-1]).reshape(-1).tolist()
+        ψ = round.(Int, pyconvert(Vector{T}, spin_config))
         λ = α * (pyconvert(T, solver.result["energies"][i-1]) + β)
 
         samples[i] = Sample{T}(ψ, λ)
@@ -159,7 +158,7 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
         ),
     )
 
-    return SampleSet{T}(samples, metadata)
+    return SampleSet{T}(samples, metadata; sense = :min, domain = :spin)
 end
 
 end # module CoherentIsingMachine

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,25 @@
+using Pkg
+using TOML
+using Test
+
 using CIMOptimizer: CIMOptimizer, MOI, QUBODrivers
 
-QUBODrivers.test(CIMOptimizer.Optimizer; examples=true) do model
-    MOI.set(model, MOI.Silent(), true)
+@testset "Dependencies" begin
+    @test !any(dep -> dep.name == "Anneal", values(Pkg.dependencies()))
+
+    conda = TOML.parsefile(joinpath(pkgdir(CIMOptimizer), "CondaPkg.toml"))
+    pip_deps = get(get(conda, "pip", Dict{String,Any}()), "deps", Dict{String,Any}())
+
+    @test haskey(conda["deps"], "pytorch-cpu")
+    @test !haskey(pip_deps, "torch")
+end
+
+@testset "QUBODrivers interface" begin
+    QUBODrivers.test(CIMOptimizer.Optimizer; examples=true) do model
+        MOI.set(model, MOI.Silent(), true)
+        MOI.set(model, MOI.RawOptimizerAttribute("hyperparameters_randomtune"), false)
+        MOI.set(model, MOI.RawOptimizerAttribute("num_timesteps_per_run"), 10)
+        MOI.set(model, MOI.RawOptimizerAttribute("return_number_of_solutions"), 1)
+        MOI.set(model, MOI.RawOptimizerAttribute("return_spin_trajectories_all_runs"), false)
+    end
 end


### PR DESCRIPTION
## Summary

- Update QUBODrivers compatibility to 0.4 and adapt the sampler to the current QUBODrivers/QUBOTools API.
- Move Python torch resolution to conda-forge `pytorch-cpu` so installs do not pull large PyPI CUDA torch wheels.
- Add dependency tests that verify Anneal is not in the resolved Julia dependency graph and PyPI torch is not requested.

## Tests run

- `julia --project=. -e 'using Pkg, TOML; Pkg.resolve(); deps = Pkg.dependencies(); @assert !any(dep -> dep.name == "Anneal", values(deps)); conda = TOML.parsefile("CondaPkg.toml"); pip_deps = get(get(conda, "pip", Dict{String,Any}()), "deps", Dict{String,Any}()); @assert haskey(conda["deps"], "pytorch-cpu"); @assert !haskey(pip_deps, "torch"); println("dependency checks passed")'` - passed.
- `julia --project=. -e 'using Pkg; Pkg.test()'` - passed.

## Notes

- The first local full test attempt failed before this change because PyPI torch tried to extract CUDA wheels and exhausted local disk space. After switching to `pytorch-cpu`, the full package test passed locally.

Closes #4
