### PR TITLE
Modernize Julia CI and QUBODrivers compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - version: '1.10'
+            os: ubuntu-latest
+            arch: x64
           - version: '1'
             os: ubuntu-latest
             arch: x64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## Unreleased
 
-- Raised the supported Julia floor to 1.10 and QUBODrivers compatibility to include 0.4 and 0.5.
+- Raised the supported Julia floor to 1.10 and QUBODrivers compatibility to 0.5.
 - Updated CI coverage to test Julia 1.10 explicitly plus the latest stable Julia release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## Unreleased
 
-- Raised the supported Julia floor to 1.10 and QUBODrivers compatibility to 0.4.
+- Raised the supported Julia floor to 1.10 and QUBODrivers compatibility to include 0.4 and 0.5.
 - Updated CI coverage to test Julia 1.10 explicitly plus the latest stable Julia release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Unreleased
+
+- Raised the supported Julia floor to 1.10 and QUBODrivers compatibility to 0.4.
+- Updated CI coverage to test Julia 1.10 explicitly plus the latest stable Julia release.

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ QUBODrivers = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
 
 [compat]
 PythonCall = "0.9"
-QUBODrivers = "0.4"
+QUBODrivers = "0.4, 0.5"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ QUBODrivers = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
 
 [compat]
 PythonCall = "0.9"
-QUBODrivers = "0.4, 0.5"
+QUBODrivers = "0.5"
 julia = "1.10"
 
 [extras]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ end
     compat = project["compat"]
 
     @test compat["julia"] == "1.10"
-    @test compat["QUBODrivers"] == "0.4"
+    @test compat["QUBODrivers"] == "0.4, 0.5"
 
     ci = read(joinpath(pkgdir(CIMOptimizer), ".github", "workflows", "ci.yml"), String)
     ci_versions = Set(m.captures[1] for m in eachmatch(r"version:\s*'([^']+)'", ci))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ end
     compat = project["compat"]
 
     @test compat["julia"] == "1.10"
-    @test compat["QUBODrivers"] == "0.4, 0.5"
+    @test compat["QUBODrivers"] == "0.5"
 
     ci = read(joinpath(pkgdir(CIMOptimizer), ".github", "workflows", "ci.yml"), String)
     ci_versions = Set(m.captures[1] for m in eachmatch(r"version:\s*'([^']+)'", ci))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,20 @@ using CIMOptimizer: CIMOptimizer, MOI, QUBODrivers
     @test !haskey(pip_deps, "torch")
 end
 
+@testset "Julia support policy" begin
+    project = TOML.parsefile(joinpath(pkgdir(CIMOptimizer), "Project.toml"))
+    compat = project["compat"]
+
+    @test compat["julia"] == "1.10"
+    @test compat["QUBODrivers"] == "0.4"
+
+    ci = read(joinpath(pkgdir(CIMOptimizer), ".github", "workflows", "ci.yml"), String)
+    ci_versions = Set(m.captures[1] for m in eachmatch(r"version:\s*'([^']+)'", ci))
+
+    @test compat["julia"] in ci_versions
+    @test "1" in ci_versions
+end
+
 @testset "QUBODrivers interface" begin
     QUBODrivers.test(CIMOptimizer.Optimizer; examples=true) do model
         MOI.set(model, MOI.Silent(), true)


### PR DESCRIPTION
## Summary

- Add an explicit Julia 1.10 CI lane to cover the package's advertised minimum supported Julia version.
- Add a support-policy regression test that checks Project.toml compat against the CI matrix.
- Require QUBODrivers `0.5` after validating the package and backend smoke tests against QUBODrivers v0.5.0.
- Add an Unreleased changelog note documenting the Julia floor and QUBODrivers modernization.

## Tests run

- `julia --project=. -e 'using Pkg; Pkg.test()'` - passed on Julia 1.10.11 with QUBODrivers v0.5.0.
- `julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` - passed on Julia 1.12.6 with QUBODrivers v0.5.0.
- `julia --project=. -e 'using Pkg; Pkg.activate(; temp=true); Pkg.develop(path=pwd()); Pkg.add(Pkg.PackageSpec(name="QUBODrivers", version="0.5.0")); Pkg.test("CIMOptimizer")'` - passed, confirming a fresh resolver can install and test CIMOptimizer with QUBODrivers v0.5.0.

## Notes

- No docs build, lint, type-check, or formatting commands are documented in README, CI, package files, or repository config beyond the Julia build/test workflow.

Closes #5
Closes #8
