### PR TITLE
Add Dependabot maintenance config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+# This same-repository Dependabot setup does not require a PAT or new repository
+# secret. Use a PAT only for future cross-repository automation that the default
+# GITHUB_TOKEN cannot access.
+updates:
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      root-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,18 @@ end
     @test "1" in ci_versions
 end
 
+@testset "Dependency maintenance policy" begin
+    config = read(joinpath(pkgdir(CIMOptimizer), ".github", "dependabot.yml"), String)
+    normalized = replace(config, r"\s+" => " ")
+    workflows = readdir(joinpath(pkgdir(CIMOptimizer), ".github", "workflows"))
+
+    @test occursin("version: 2", config)
+    @test occursin("""package-ecosystem: "julia" directory: "/" """, normalized)
+    @test occursin("""package-ecosystem: "github-actions" directory: "/" """, normalized)
+    @test occursin("root-julia-dependencies", config)
+    @test !any(workflow -> occursin("compathelper", lowercase(workflow)), workflows)
+end
+
 @testset "QUBODrivers interface" begin
     QUBODrivers.test(CIMOptimizer.Optimizer; examples=true) do model
         MOI.set(model, MOI.Silent(), true)


### PR DESCRIPTION
Summary
- Add `.github/dependabot.yml` for weekly root Julia dependency updates and monthly GitHub Actions updates.
- Document that this same-repository Dependabot setup needs no PAT or new repository secret; a PAT is only for future cross-repository automation that the default `GITHUB_TOKEN` cannot access.
- Add a test guard confirming Dependabot is configured for Julia and GitHub Actions and that no CompatHelper workflow is present.

Tests
- `julia +release --project=. -e 'using Pkg; Pkg.test()'` passed.
- Re-ran `julia +release --project=. -e 'using Pkg; Pkg.test()'` after the final Dependabot comment edit; passed.

Notes
- This repository has no `docs/` environment and no documentation deployment workflow, so the Dependabot-only `--skip-deploy` guard from the reference repositories is not needed here.

Issue: https://github.com/JuliaQUBO/CIMOptimizer.jl/issues/11

Closes #11
