### PR TITLE
Benchmark Julia action cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
+permissions:
+  actions: write
+  contents: read
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       # - uses: julia-actions/julia-processcoverage@v1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,6 +41,7 @@ end
     @test cache !== nothing
     @test buildpkg !== nothing
     @test last(setup) < first(cache) < first(buildpkg)
+    @test occursin(r"(?m)^permissions:\n\s+actions:\s*write\n\s+contents:\s*read", ci)
 end
 
 @testset "Dependency maintenance policy" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,15 @@ end
 
     @test compat["julia"] in ci_versions
     @test "1" in ci_versions
+
+    setup = findfirst("julia-actions/setup-julia@v3", ci)
+    cache = findfirst("julia-actions/cache@v3", ci)
+    buildpkg = findfirst("julia-actions/julia-buildpkg@v1", ci)
+
+    @test setup !== nothing
+    @test cache !== nothing
+    @test buildpkg !== nothing
+    @test last(setup) < first(cache) < first(buildpkg)
 end
 
 @testset "Dependency maintenance policy" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,7 @@ end
     @test compat["QUBODrivers"] == "0.5"
 
     ci = read(joinpath(pkgdir(CIMOptimizer), ".github", "workflows", "ci.yml"), String)
+    normalized_ci = replace(ci, "\r\n" => "\n")
     ci_versions = Set(m.captures[1] for m in eachmatch(r"version:\s*'([^']+)'", ci))
 
     @test compat["julia"] in ci_versions
@@ -41,7 +42,7 @@ end
     @test cache !== nothing
     @test buildpkg !== nothing
     @test last(setup) < first(cache) < first(buildpkg)
-    @test occursin(r"(?m)^permissions:\n\s+actions:\s*write\n\s+contents:\s*read", ci)
+    @test occursin(r"(?m)^permissions:\n\s+actions:\s*write\n\s+contents:\s*read", normalized_ci)
 end
 
 @testset "Dependency maintenance policy" begin


### PR DESCRIPTION
Summary
- Adds `julia-actions/cache@v3` after `julia-actions/setup-julia@v3` and before `julia-actions/julia-buildpkg@v1`.
- Adds a workflow policy test that verifies the cache step is present in that order.

Benchmark
- Issue baseline snapshot: Julia 1.10 Ubuntu 2m34s, Julia 1 Ubuntu 3m13s, Julia 1 Windows 10m16s.
- First PR run, cache-populating attempt: Julia 1.10 Ubuntu 3m09s, Julia 1 Ubuntu 4m19s, Julia 1 Windows 11m13s.
- Warm-cache rerun: Julia 1.10 Ubuntu 1m44s, Julia 1 Ubuntu 1m59s, Julia 1 Windows 7m16s.
- Warm-cache critical path improved by 3m00s versus the issue baseline Windows job, about 29%.
- Warm-cache critical path improved by 3m57s versus the cache-populating PR run, about 35%.

Cache verification
- Warm-run logs show cache hits and successful restores from attempt 1 for all three matrix jobs.
- Warm-run logs show successful cache saves for attempt 2 for all three matrix jobs.
- The post-cache cleanup logged non-fatal HTTP 403 messages when deleting old PR caches; restore/save completed and all jobs passed.

Tests
- `julia --project=. -e 'using Pkg; Pkg.test()'` passed.
- `git diff --check` passed.
- CI passed twice on PR #16: first run to populate caches, second run to measure warm-cache behavior.

Notes
- Based on the warm-cache timings, the improvement is material enough to keep the cache step.

Closes #15
