### PR TITLE
Update QUBODrivers 0.6 benchmark conformance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,13 +4,14 @@ authors = ["pedromxavier <pedrox@cos.ufrj.br>", "David E. Bernal Neira <dbernaln
 version = "0.2.0"
 
 [deps]
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 QUBODrivers = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
 
 [compat]
 PythonCall = "0.9"
-QUBODrivers = "0.5, 0.6"
+QUBODrivers = "0.6.1"
 julia = "1.10"
 
 [extras]

--- a/src/CIMOptimizer.jl
+++ b/src/CIMOptimizer.jl
@@ -2,14 +2,34 @@ module CIMOptimizer
 
 using PythonCall
 using LinearAlgebra
+using Libdl
 using QUBODrivers: QUBODrivers, QUBOTools, MOI, Sample, SampleSet
 
 const np = PythonCall.pynew()
 const co = PythonCall.pynew()
 const co_si = PythonCall.pynew()
 const torch = PythonCall.pynew()
+const _preloaded_libraries = Ptr{Nothing}[]
+
+function _preload_python_env_libraries()
+    Sys.islinux() || return nothing
+
+    prefix = pyconvert(String, pyimport("sys").prefix)
+    libdir = joinpath(prefix, "lib")
+
+    for lib in ("libmkl_core.so.3", "libmkl_gnu_thread.so.3", "libmkl_intel_lp64.so.3")
+        path = joinpath(libdir, lib)
+        isfile(path) || continue
+
+        handle = Libdl.dlopen(path, Libdl.RTLD_LAZY | Libdl.RTLD_GLOBAL)
+        push!(_preloaded_libraries, handle)
+    end
+
+    return nothing
+end
 
 function __init__()
+    _preload_python_env_libraries()
     PythonCall.pycopy!(np, pyimport("numpy"))
     PythonCall.pycopy!(co, pyimport("cim_optimizer"))
     PythonCall.pycopy!(co_si, pyimport("cim_optimizer.solve_Ising"))
@@ -21,9 +41,9 @@ QUBODrivers.@setup Optimizer begin
     version = v"1.0.4" # cim-optimizer version
     attributes = begin
         "target_energy"::Number = -Inf                                  # Assumed target/ground energy for the solver to reach, used to stop before num_runs runs have been completed.
-        "num_runs"::Integer = 1                                         # Maximum number of runs to attempt by the CIM, either running the set repeated number of repetitions or stopping if the target energy is met.
+        NumberOfRuns["num_runs"]::Integer = 1                           # Maximum number of runs to attempt by the CIM, either running the set repeated number of repetitions or stopping if the target energy is met.
         "num_timesteps_per_run"::Integer = 1_000                        # Roundtrip number per run, representing the number of MVM’s per run.
-        "max_wallclock_time_allowed"::Integer = 10_000_000              # Seconds passed by the CIM before quitting if num_runs or target_energy have not been met.
+        MaxWallclockTimeAllowed["max_wallclock_time_allowed"]::Real = 10_000_000.0 # Seconds before quitting if num_runs or target_energy have not been met.
         "stop_when_target_energy_reached"::Bool = true                  # Stop if target energy reached before completing all the CIM runs.
         "custom_feedback_schedule"::Any = nothing                       # Option to specify a custom function or array of length num_timesteps_per_run to use as a feedback schedule.
         "custom_pump_schedule"::Any = nothing                           # Option to specify a custom function or array of length num_timesteps_per_run to use as a pump schedule.
@@ -62,13 +82,17 @@ QUBODrivers.@setup Optimizer begin
         "return_lowest_energies_found_spin_configuration"::Bool = false # Return a vector where for each run, it gives the spin configuration that was found during that run that had the lowest energy.
         "return_lowest_energy_found_from_each_run"::Bool = true         # Return a vector with the lowest energy found for each run.
         "return_spin_trajectories_all_runs"::Bool = true                # Return the Ising spin trajectory for every run.
-        "return_number_of_solutions"::Integer = 1_000                   # Number of best solutions to return; must be <= num_runs.
+        ReturnNumberOfSolutions["return_number_of_solutions"]::Integer = 1_000 # Number of best solutions to return; must be <= num_runs.
         "suppress_statements"::Bool = false                             # Print details of each solver call to screen/REPL.
         "use_GPU"::Bool = false                                         # Option to use GPU acceleration using PyTroch libraries.
         "use_CAC"::Bool = true                                          # Option to select CAC or AHC solver for no external field.
         "chosen_device"::Any = nothing # torch.device("cpu")            # Device used for torch-based computations.
     end
 end
+
+QUBODrivers.supports_seed(::Type{<:Optimizer}) = false
+QUBODrivers.honors_final_reads(::Type{<:Optimizer}) = true
+QUBODrivers.enforces_time_limit(::Type{<:Optimizer}) = false
 
 function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     _, h, J, α, β, _, _ = QUBOTools.ising(sampler, :dense; sense = :min)
@@ -81,7 +105,9 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     model = co_si.Ising(J, h)
 
     # Retrieve attributes
-    num_runs = MOI.get(sampler, MOI.RawOptimizerAttribute("num_runs"))
+    num_runs = MOI.get(sampler, NumberOfRuns())
+    final_num_reads = something(MOI.get(sampler, QUBODrivers.FinalNumberOfReads()), num_runs)
+    num_samples = min(num_runs, final_num_reads)
 
     if MOI.get(sampler, MOI.Silent())
         MOI.set(sampler, MOI.RawOptimizerAttribute("suppress_statements"), true)
@@ -93,9 +119,9 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
 
     solver = model.solve(;
         target_energy                                   = MOI.get(sampler, MOI.RawOptimizerAttribute("target_energy")),
-        num_runs                                        = MOI.get(sampler, MOI.RawOptimizerAttribute("num_runs")),
+        num_runs                                        = MOI.get(sampler, NumberOfRuns()),
         num_timesteps_per_run                           = MOI.get(sampler, MOI.RawOptimizerAttribute("num_timesteps_per_run")),
-        max_wallclock_time_allowed                      = MOI.get(sampler, MOI.RawOptimizerAttribute("max_wallclock_time_allowed")),
+        max_wallclock_time_allowed                      = MOI.get(sampler, MaxWallclockTimeAllowed()),
         stop_when_target_energy_reached                 = MOI.get(sampler, MOI.RawOptimizerAttribute("stop_when_target_energy_reached")),
         custom_feedback_schedule                        = MOI.get(sampler, MOI.RawOptimizerAttribute("custom_feedback_schedule")),
         custom_pump_schedule                            = MOI.get(sampler, MOI.RawOptimizerAttribute("custom_pump_schedule")),
@@ -134,16 +160,16 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
         return_lowest_energies_found_spin_configuration = MOI.get(sampler, MOI.RawOptimizerAttribute("return_lowest_energies_found_spin_configuration")),
         return_lowest_energy_found_from_each_run        = MOI.get(sampler, MOI.RawOptimizerAttribute("return_lowest_energy_found_from_each_run")),
         return_spin_trajectories_all_runs               = MOI.get(sampler, MOI.RawOptimizerAttribute("return_spin_trajectories_all_runs")),
-        return_number_of_solutions                      = MOI.get(sampler, MOI.RawOptimizerAttribute("return_number_of_solutions")),
+        return_number_of_solutions                      = MOI.get(sampler, ReturnNumberOfSolutions()),
         suppress_statements                             = MOI.get(sampler, MOI.RawOptimizerAttribute("suppress_statements")),
         use_GPU                                         = MOI.get(sampler, MOI.RawOptimizerAttribute("use_GPU")),
         use_CAC                                         = MOI.get(sampler, MOI.RawOptimizerAttribute("use_CAC")),
         chosen_device                                   = something(MOI.get(sampler, MOI.RawOptimizerAttribute("chosen_device")), torch.device("cpu")),
     )
 
-    samples = Vector{Sample{T,Int}}(undef, num_runs)
+    samples = Vector{Sample{T,Int}}(undef, num_samples)
 
-    for i = 1:num_runs
+    for i = 1:num_samples
         spin_config = np.asarray(solver.result["spin_config_all_runs"][i-1]).reshape(-1).tolist()
         ψ = round.(Int, pyconvert(Vector{T}, spin_config))
         λ = α * (pyconvert(T, solver.result["energies"][i-1]) + β)
@@ -151,11 +177,23 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
         samples[i] = Sample{T}(ψ, λ)
     end
 
-    metadata = Dict{String,Any}(
-        "origin" => "cim-optimizer",
-        "time"   => Dict{String,Any}(
-            "effective" => solver.result["time"]
-        ),
+    effective_time = pyconvert(Float64, solver.result["time"])
+    metadata = QUBODrivers._sampler_metadata(
+        origin                = "CIMOptimizer.jl",
+        algorithm_name        = "Coherent Ising Machine",
+        backend_name          = "cim-optimizer",
+        backend_version       = v"1.0.4",
+        execution_mode        = "simulation",
+        optimizer_iterations  = MOI.get(sampler, MOI.RawOptimizerAttribute("num_timesteps_per_run")),
+        optimizer_evaluations = num_runs,
+        number_of_reads       = num_runs,
+        final_number_of_reads = length(samples),
+        status                = "locally_solved",
+        termination_status    = MOI.LOCALLY_SOLVED,
+    )
+    metadata["time"] = Dict{String,Any}("effective" => effective_time)
+    metadata["cim_optimizer"] = Dict{String,Any}(
+        "time" => Dict{String,Any}("python_solve" => effective_time),
     )
 
     return SampleSet{T}(samples, metadata; sense = :min, domain = :spin)

--- a/src/CIMOptimizer.jl
+++ b/src/CIMOptimizer.jl
@@ -117,7 +117,7 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
         MOI.set(sampler, MOI.RawOptimizerAttribute("max_wallclock_time_allowed"), MOI.get(sampler, MOI.TimeLimitSec()))
     end
 
-    solver = model.solve(;
+    solve_results = @timed model.solve(;
         target_energy                                   = MOI.get(sampler, MOI.RawOptimizerAttribute("target_energy")),
         num_runs                                        = MOI.get(sampler, NumberOfRuns()),
         num_timesteps_per_run                           = MOI.get(sampler, MOI.RawOptimizerAttribute("num_timesteps_per_run")),
@@ -166,6 +166,7 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
         use_CAC                                         = MOI.get(sampler, MOI.RawOptimizerAttribute("use_CAC")),
         chosen_device                                   = something(MOI.get(sampler, MOI.RawOptimizerAttribute("chosen_device")), torch.device("cpu")),
     )
+    solver = solve_results.value
 
     samples = Vector{Sample{T,Int}}(undef, num_samples)
 
@@ -177,7 +178,9 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
         samples[i] = Sample{T}(ψ, λ)
     end
 
-    effective_time = pyconvert(Float64, solver.result["time"])
+    python_solve_time = pyconvert(Float64, solver.result["time"])
+    julia_solve_time = solve_results.time
+    effective_time = min(python_solve_time, julia_solve_time)
     metadata = QUBODrivers._sampler_metadata(
         origin                = "CIMOptimizer.jl",
         algorithm_name        = "Coherent Ising Machine",
@@ -193,7 +196,10 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     )
     metadata["time"] = Dict{String,Any}("effective" => effective_time)
     metadata["cim_optimizer"] = Dict{String,Any}(
-        "time" => Dict{String,Any}("python_solve" => effective_time),
+        "time" => Dict{String,Any}(
+            "python_solve" => python_solve_time,
+            "julia_solve_call" => julia_solve_time,
+        ),
     )
 
     return SampleSet{T}(samples, metadata; sense = :min, domain = :spin)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ end
     compat = project["compat"]
 
     @test compat["julia"] == "1.10"
-    @test compat["QUBODrivers"] == "0.5, 0.6"
+    @test compat["QUBODrivers"] == "0.6.1"
 
     ci = read(joinpath(pkgdir(CIMOptimizer), ".github", "workflows", "ci.yml"), String)
     normalized_ci = replace(ci, "\r\n" => "\n")
@@ -57,8 +57,35 @@ end
     @test !any(workflow -> occursin("compathelper", lowercase(workflow)), workflows)
 end
 
+@testset "Typed attributes and capabilities" begin
+    sampler = CIMOptimizer.Optimizer{Float64}()
+
+    @test MOI.supports(sampler, CIMOptimizer.NumberOfRuns())
+    @test MOI.supports(sampler, CIMOptimizer.MaxWallclockTimeAllowed())
+    @test MOI.supports(sampler, CIMOptimizer.ReturnNumberOfSolutions())
+    @test MOI.supports(sampler, QUBODrivers.FinalNumberOfReads())
+    @test !MOI.supports(sampler, QUBODrivers.RandomSeed())
+
+    MOI.set(sampler, CIMOptimizer.NumberOfRuns(), 3)
+    MOI.set(sampler, CIMOptimizer.MaxWallclockTimeAllowed(), 2.5)
+    MOI.set(sampler, CIMOptimizer.ReturnNumberOfSolutions(), 2)
+    MOI.set(sampler, QUBODrivers.FinalNumberOfReads(), 2)
+
+    @test MOI.get(sampler, CIMOptimizer.NumberOfRuns()) == 3
+    @test MOI.get(sampler, MOI.RawOptimizerAttribute("num_runs")) == 3
+    @test MOI.get(sampler, CIMOptimizer.MaxWallclockTimeAllowed()) == 2.5
+    @test MOI.get(sampler, MOI.RawOptimizerAttribute("max_wallclock_time_allowed")) == 2.5
+    @test MOI.get(sampler, CIMOptimizer.ReturnNumberOfSolutions()) == 2
+    @test MOI.get(sampler, MOI.RawOptimizerAttribute("return_number_of_solutions")) == 2
+    @test MOI.get(sampler, QUBODrivers.FinalNumberOfReads()) == 2
+
+    @test !QUBODrivers.supports_seed(CIMOptimizer.Optimizer)
+    @test QUBODrivers.honors_final_reads(CIMOptimizer.Optimizer)
+    @test !QUBODrivers.enforces_time_limit(CIMOptimizer.Optimizer)
+end
+
 @testset "QUBODrivers interface" begin
-    QUBODrivers.test(CIMOptimizer.Optimizer; examples=true) do model
+    QUBODrivers.test(CIMOptimizer.Optimizer; examples=true, benchmark_conformance=true) do model
         MOI.set(model, MOI.Silent(), true)
         MOI.set(model, MOI.RawOptimizerAttribute("hyperparameters_randomtune"), false)
         MOI.set(model, MOI.RawOptimizerAttribute("num_timesteps_per_run"), 10)


### PR DESCRIPTION
Summary

- Updates QUBODrivers compat to 0.6.1 and adds the required stdlib dependency entry.
- Adopts QUBODrivers 0.6 metadata with backend, timing, read-count, and termination fields.
- Promotes campaign-relevant attributes for number of runs, wallclock limit, and returned solutions while leaving long-tail backend parameters as raw attributes.
- Declares capability traits for seed support, final-read handling, and time-limit enforcement.
- Preloads the Linux MKL runtime from the active Python environment before importing torch to avoid duplicate OpenMP runtime failures.
- Reports `metadata["time"]["effective"]` from a Julia solve-call timer bounded inside QUBODrivers sampling, while preserving the backend-reported Python time under `metadata["cim_optimizer"]["time"]["python_solve"]`.

Tests

- `julia --project=. -e 'using CIMOptimizer; using MathOptInterface; const MOI = MathOptInterface; model = CIMOptimizer.Optimizer{Float64}(); @assert MOI.supports(model, CIMOptimizer.NumberOfRuns()); @assert MOI.supports(model, CIMOptimizer.MaxWallclockTimeAllowed()); @assert MOI.supports(model, CIMOptimizer.ReturnNumberOfSolutions())'`: passed.
- `julia --project=. -e 'using Pkg; Pkg.test()'`: passed.
- `/home/bernalde/.julia/juliaup/julia-1.10.11+0.x64.linux.gnu/bin/julia --project=/tmp/cimoptimizer-fresh.ncfkMe -e 'using Pkg; Pkg.test()'`: passed in a fresh no-manifest copy, resolving QUBODrivers v0.6.1 and QUBOTools v0.13.0.
- Temp environment with `QUBO@0.6` plus this branch via `Pkg.develop`: passed.
- `git diff --check`: passed.

Notes

- A combined temp environment with `QUBO@0.6`, PySA, DWave, and this branch did not resolve because the currently registered PySA release caps QUBODrivers at 0.5.1 and the currently registered DWave release is incompatible with QUBODrivers 0.6 / QUBOTools 0.13. This PR does not change those external package compat bounds.

Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `45df7b4231ef82b83a2e97ae8aa5b44fdf742f9e`
- Head branch: `fix/issue-18-qubodrivers-compat`
- Stacked status: not stacked
- Prerequisite PRs: none

Refs #18
