### PR TITLE
Support Python 3.11 CondaPkg runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Widened the CondaPkg Python runtime bound to include Python 3.11.
+- Added a CondaPkg resolve and `CIMOptimizer` import smoke test.
+- Documented the remaining QiskitOpt shared-environment NumPy constraint.
+
 ## v0.2.1 - 2026-06-12
 
 - Updated QUBODrivers compatibility to 0.6.1 for QUBO.jl v0.6 ecosystem resolution.

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,7 +1,7 @@
 channels = ["conda-forge", "anaconda"]
 
 [deps]
-python = ">=3.8,<3.12"
+python = ">=3.10,<3.12"
 pytorch-cpu = ">=2.0.1"
 
 [pip.deps]

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,8 +1,7 @@
 channels = ["conda-forge", "anaconda"]
 
 [deps]
-python = ">=3.8,<3.11"
-numpy = ">=1.20.0"
+python = ">=3.8,<3.12"
 pytorch-cpu = ">=2.0.1"
 
 [pip.deps]

--- a/Project.toml
+++ b/Project.toml
@@ -15,9 +15,10 @@ QUBODrivers = "0.6.1"
 julia = "1.10"
 
 [extras]
+CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Pkg", "TOML", "Test"]
+test = ["CondaPkg", "Pkg", "TOML", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 QUBODrivers = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
 
 [compat]
+CondaPkg = "0.2"
 PythonCall = "0.9"
 QUBODrivers = "0.6.1"
 julia = "1.10"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ julia> import Pkg; Pkg.add(url="https://github.com/JuliaQUBO/CIMOptimizer.jl")
 julia> using CIMOptimizer
 ```
 
+## Python runtime compatibility
+
+`CIMOptimizer` uses PythonCall and CondaPkg to install `cim-optimizer ==1.0.4`
+with conda `pytorch-cpu`. The CondaPkg runtime supports Python `>=3.8,<3.12`,
+including Python 3.11 for shared benchmark environments with `DWave v0.7.2`.
+
+`QiskitOpt v0.7.0` currently requires an isolated Python environment when used
+alongside `CIMOptimizer`. Its PyPI `numpy ~=2.2.0` constraint conflicts with the
+conda NumPy version pinned by the `pytorch-cpu` stack used here.
+
 ## Getting started
 ```julia
 using JuMP

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ julia> using CIMOptimizer
 ## Python runtime compatibility
 
 `CIMOptimizer` uses PythonCall and CondaPkg to install `cim-optimizer ==1.0.4`
-with conda `pytorch-cpu`. The CondaPkg runtime supports Python `>=3.8,<3.12`,
+with conda `pytorch-cpu`. The CondaPkg runtime supports Python `>=3.10,<3.12`,
 including Python 3.11 for shared benchmark environments with `DWave v0.7.2`.
 
 `QiskitOpt v0.7.0` currently requires an isolated Python environment when used

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ end
     @test haskey(conda["deps"], "pytorch-cpu")
     @test !haskey(conda["deps"], "numpy")
     @test !haskey(pip_deps, "torch")
-    @test conda["deps"]["python"] == ">=3.8,<3.12"
+    @test conda["deps"]["python"] == ">=3.10,<3.12"
 end
 
 @testset "Julia support policy" begin
@@ -33,6 +33,7 @@ end
     compat = project["compat"]
 
     @test compat["julia"] == "1.10"
+    @test compat["CondaPkg"] == "0.2"
     @test compat["QUBODrivers"] == "0.6.1"
 
     ci = read(joinpath(pkgdir(CIMOptimizer), ".github", "workflows", "ci.yml"), String)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,14 @@
+using CondaPkg
 using Pkg
 using TOML
 using Test
 
-using CIMOptimizer: CIMOptimizer, MOI, QUBODrivers
+@testset "CondaPkg runtime smoke" begin
+    CondaPkg.resolve()
+    @eval using CIMOptimizer: CIMOptimizer, MOI, QUBODrivers
+
+    @test isdefined(CIMOptimizer, :Optimizer)
+end
 
 @testset "Package metadata" begin
     project = TOML.parsefile(joinpath(pkgdir(CIMOptimizer), "Project.toml"))
@@ -17,7 +23,9 @@ end
     pip_deps = get(get(conda, "pip", Dict{String,Any}()), "deps", Dict{String,Any}())
 
     @test haskey(conda["deps"], "pytorch-cpu")
+    @test !haskey(conda["deps"], "numpy")
     @test !haskey(pip_deps, "torch")
+    @test conda["deps"]["python"] == ">=3.8,<3.12"
 end
 
 @testset "Julia support policy" begin


### PR DESCRIPTION
## Summary

- Widened the CondaPkg Python runtime from `>=3.8,<3.11` to `>=3.10,<3.12`, allowing Python 3.11 environments while matching PythonCall's effective floor.
- Removed the direct conda `numpy` dependency so NumPy is provided by the Python package stack instead of an extra CIMOptimizer conda pin.
- Added a test-time `CondaPkg.resolve()` and `CIMOptimizer` import smoke.
- Added a `CondaPkg = "0.2"` compat bound for the test extra.
- Documented that `DWave v0.7.2` can share the Python 3.11 runtime, while `QiskitOpt v0.7.0` still needs isolation because its PyPI `numpy ~=2.2.0` constraint conflicts with the conda NumPy pinned by the `pytorch-cpu` stack.

Closes #20

## Tests

- `git diff --check` passed.
- `julia --project=. -e 'using Pkg; Pkg.test()'` passed.
- `julia -e 'using Pkg; Pkg.activate(; temp=true); Pkg.develop(PackageSpec(path=pwd())); Pkg.add("CondaPkg"); using CondaPkg; CondaPkg.resolve(); using CIMOptimizer; println(CIMOptimizer.PythonCall.pyconvert(String, CIMOptimizer.PythonCall.pyimport("sys").version)); println("imported")'` passed, selected Python 3.11.15, and imported `CIMOptimizer`.
- `julia -e 'using Pkg; Pkg.activate(; temp=true); Pkg.develop(PackageSpec(path=pwd())); Pkg.add(PackageSpec(name="DWave", version="0.7.2")); Pkg.add("CondaPkg"); using CondaPkg; CondaPkg.resolve(); println("CIMOptimizer + DWave resolved")'` passed.
- `julia -e 'using Pkg; Pkg.activate(; temp=true); Pkg.develop(PackageSpec(path=pwd())); Pkg.add(PackageSpec(name="QiskitOpt", version="0.7.0")); Pkg.add("CondaPkg"); using CondaPkg; CondaPkg.resolve(); println("CIMOptimizer + QiskitOpt resolved")'` still fails with a Pixi PyPI solve conflict between QiskitOpt's `numpy>=2.2.0,<2.3.dev0` and conda-pinned `numpy==2.4.6`; this is documented in the README.

No separate lint or format command is documented beyond the Julia test workflow and `git diff --check`.

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `74f1dc08d452db9249c370a1e5398a25dd0d6b54`
- Stacked status: not stacked
- Prerequisite PRs: none
