### PR TITLE
Release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.2.2 - 2026-06-27
 
 - Widened the CondaPkg Python runtime bound to include Python 3.11.
 - Added a CondaPkg resolve and `CIMOptimizer` import smoke test.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CIMOptimizer"
 uuid = "f763a312-2f8b-4ea4-ad8b-371148ce3a7b"
 authors = ["pedromxavier <pedrox@cos.ufrj.br>", "David E. Bernal Neira <dbernaln@purdue.edu>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"


### PR DESCRIPTION
## Summary

- Bump `Project.toml` to `v0.2.2`.
- Move the Python 3.11 CondaPkg runtime work from `Unreleased` to the `v0.2.2` changelog entry.

This release publishes the `CondaPkg.toml` changes needed for downstream benchmark environments to resolve the updated Python runtime bounds.

## Tests

- `git diff --check`
- `julia --project=. -e 'using Pkg; Pkg.test()'`

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `56dd5477f1c49f13aeca30bf074674995f1541e6`
- Stacked status: not stacked
- Prerequisite PRs: none
